### PR TITLE
Add UI and functionality for managing disabled sites settings

### DIFF
--- a/data/content_script/inject.js
+++ b/data/content_script/inject.js
@@ -30,50 +30,39 @@ var background = (function () {
 })();
 
 var config = {
+  "injected": {
+    "devices": false,
+    "support": false,
+    "additional": false
+  },
+  "script": function (key, path) {
+    if (config.injected[key]) return;
+    /*  */
+    const root = document.documentElement || document.head || document.body;
+    if (!root) return;
+    /*  */
+    config.injected[key] = true;
+    /*  */
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.onload = function () {script.remove()};
+    script.src = chrome.runtime.getURL(path);
+    /*  */
+    root.appendChild(script);
+  },
   "update": function (e) {
     if (e.state === "enabled") {
-      const script = {};
       /*  */
       if (e.devices) {
-        script.a = document.getElementById("webrtc-control-a");
-        /*  */
-        if (!script.a) {
-          script.a = document.createElement("script");
-          script.a.type = "text/javascript";
-          script.a.setAttribute("id", "webrtc-control-a");
-          script.a.onload = function () {script.a.remove()};
-          script.a.src = chrome.runtime.getURL("data/content_script/page_context/media_devices.js");
-          /*  */
-          document.documentElement.appendChild(script.a);
-        }
+        config.script("devices", "data/content_script/page_context/media_devices.js");
       }
       /*  */
       if (e.inject) {
-        script.b = document.getElementById("webrtc-control-b");
-        /*  */
-        if (!script.b) {
-          script.b = document.createElement("script");
-          script.b.type = "text/javascript";
-          script.b.setAttribute("id", "webrtc-control-b");
-          script.b.onload = function () {script.b.remove()};
-          script.b.src = chrome.runtime.getURL("data/content_script/page_context/support_detection.js");
-          /*  */
-          document.documentElement.appendChild(script.b);
-        }
+        config.script("support", "data/content_script/page_context/support_detection.js");
       }
       /*  */
       if (e.additional) {
-        script.c = document.getElementById("webrtc-control-c");
-        /*  */
-        if (!script.c) {
-          script.c = document.createElement("script");
-          script.c.type = "text/javascript";
-          script.c.setAttribute("id", "webrtc-control-c");
-          script.c.onload = function () {script.c.remove()};
-          script.c.src = chrome.runtime.getURL("data/content_script/page_context/additional_objects.js");
-          /*  */
-          document.documentElement.appendChild(script.c);
-        }
+        config.script("additional", "data/content_script/page_context/additional_objects.js");
       }
     }
   }

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -1,6 +1,6 @@
 body {
   border: 0;
-  padding: 0;
+  padding: 0 0 48px;
   color: #333;
   width: 100%;
   margin: auto;
@@ -105,6 +105,7 @@ textarea {
 
 .buttons {
   margin-top: 20px;
+  margin-bottom: 28px;
   max-width: 700px;
   border-spacing: 5px 0;
 }
@@ -116,17 +117,19 @@ textarea {
 }
 
 .blacklist-form {
-  grid-template-columns: 1fr 120px;
+  grid-template-columns: 1fr;
 }
 
 .blacklist-row {
   margin-top: 8px;
-  grid-template-columns: 1fr 120px;
+  grid-template-columns: minmax(0, 1fr) 120px;
 }
 
 .blacklist-actions {
   display: grid;
   gap: 8px;
+  grid-template-columns: repeat(3, 120px);
+  justify-content: end;
 }
 
 #blacklist-file {
@@ -152,9 +155,6 @@ textarea {
 }
 
 @media (max-width: 640px) {
-  .blacklist-form {
-    grid-template-columns: 1fr;
-  }
   .blacklist-actions {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -129,9 +129,9 @@ textarea {
 
 .blacklist-form {
   display: grid;
-  gap: 12px;
+  gap: 4px;
   grid-template-columns: 1fr;
-  margin-bottom: 22px;
+  margin-bottom: 18px;
 }
 
 .blacklist-actions {
@@ -147,7 +147,7 @@ textarea {
 
 #blacklist-status {
   min-height: 20px;
-  margin: 0 0 10px;
+  margin: 0 0 8px;
   color: #555;
   line-height: 20px;
   text-indent: 5px;
@@ -163,6 +163,10 @@ textarea {
   display: grid;
   gap: 8px;
   grid-template-columns: minmax(0, 1fr) 120px;
+}
+
+.blacklist .note {
+  margin-top: 10px;
 }
 
 #blacklist-status.error {

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -129,7 +129,6 @@ textarea {
 
 .blacklist-form {
   display: grid;
-  gap: 4px;
   grid-template-columns: 1fr;
   margin-bottom: 18px;
 }
@@ -139,6 +138,7 @@ textarea {
   gap: 8px;
   grid-template-columns: repeat(3, 120px);
   justify-content: end;
+  margin-top: 8px;
 }
 
 #blacklist-file {

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -112,15 +112,8 @@ textarea {
 }
 
 .blacklist {
-  margin-top: 24px;
-  border-spacing: 0;
-}
-
-.blacklist tr,
-.blacklist td {
   display: block;
-  height: auto;
-  line-height: normal;
+  margin: 24px 10px 0;
 }
 
 .blacklist .title {
@@ -128,8 +121,7 @@ textarea {
 }
 
 .blacklist-form {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: block;
   margin-bottom: 18px;
 }
 
@@ -138,7 +130,7 @@ textarea {
   gap: 8px;
   grid-template-columns: repeat(3, 120px);
   justify-content: end;
-  margin-top: 8px;
+  padding-top: 10px;
 }
 
 #blacklist-file {

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -58,6 +58,7 @@ input[type='checkbox'] {
   vertical-align: middle;
 }
 
+input[type='text'],
 input[type='button'] {
   margin: 0;
   padding: 0;
@@ -77,6 +78,12 @@ input[type='button']:hover {
   background: rgba(0,0,0,0.05);
 }
 
+input[type='text'] {
+  cursor: text;
+  line-height: 42px;
+  text-indent: 10px;
+}
+
 .note p {
   color: #555;
   text-indent: 5px;
@@ -90,6 +97,17 @@ input[type='button']:hover {
   margin-top: 20px;
   max-width: 700px;
   border-spacing: 5px 0;
+}
+
+.blacklist-form,
+.blacklist-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 120px;
+}
+
+.blacklist-row {
+  margin-top: 8px;
 }
 
 .logo {
@@ -108,6 +126,7 @@ input[type='button']:hover {
   }
   .container,
   .container select,
+  .container input[type='text'],
   .container input[type='button'] {
     color: #ebebeb;
     background-color: #1e1e1e;
@@ -123,6 +142,7 @@ input[type='button']:hover {
     color: #b5b5b5;
   }
   .container select,
+  .container input[type='text'],
   .container input[type='button'] {
     border-color: rgb(255 255 255 / 10%);
   }

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -87,6 +87,7 @@ textarea {
 }
 
 textarea {
+  display: block;
   height: 96px;
   resize: vertical;
   line-height: 20px;
@@ -110,19 +111,27 @@ textarea {
   border-spacing: 5px 0;
 }
 
-.blacklist-form,
-.blacklist-row {
-  display: grid;
-  gap: 8px;
+.blacklist {
+  margin-top: 24px;
+  border-spacing: 0;
+}
+
+.blacklist tr,
+.blacklist td {
+  display: block;
+  height: auto;
+  line-height: normal;
+}
+
+.blacklist .title {
+  margin-bottom: 14px;
 }
 
 .blacklist-form {
+  display: grid;
+  gap: 12px;
   grid-template-columns: 1fr;
-}
-
-.blacklist-row {
-  margin-top: 4px;
-  grid-template-columns: minmax(0, 1fr) 120px;
+  margin-bottom: 22px;
 }
 
 .blacklist-actions {
@@ -138,13 +147,22 @@ textarea {
 
 #blacklist-status {
   min-height: 20px;
-  margin-top: 12px;
+  margin: 0 0 10px;
   color: #555;
+  line-height: 20px;
   text-indent: 5px;
 }
 
 #blacklist-list {
-  margin-top: 12px;
+  display: grid;
+  gap: 4px;
+  margin-top: 0;
+}
+
+.blacklist-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 120px;
 }
 
 #blacklist-status.error {

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -1,6 +1,6 @@
 body {
   border: 0;
-  padding: 0 0 48px;
+  padding: 0 0 96px;
   color: #333;
   width: 100%;
   margin: auto;
@@ -105,7 +105,7 @@ textarea {
 
 .buttons {
   margin-top: 20px;
-  margin-bottom: 28px;
+  margin-bottom: 48px;
   max-width: 700px;
   border-spacing: 5px 0;
 }
@@ -121,7 +121,7 @@ textarea {
 }
 
 .blacklist-row {
-  margin-top: 8px;
+  margin-top: 4px;
   grid-template-columns: minmax(0, 1fr) 120px;
 }
 
@@ -138,8 +138,13 @@ textarea {
 
 #blacklist-status {
   min-height: 20px;
+  margin-top: 12px;
   color: #555;
   text-indent: 5px;
+}
+
+#blacklist-list {
+  margin-top: 12px;
 }
 
 #blacklist-status.error {

--- a/data/options/options.css
+++ b/data/options/options.css
@@ -7,7 +7,7 @@ body {
   max-width: 1080px;
 }
 
-p, body, input, label {
+p, body, input, label, textarea {
   font-size: 13px;
   font-family: arial, sans-serif;
 }
@@ -59,7 +59,8 @@ input[type='checkbox'] {
 }
 
 input[type='text'],
-input[type='button'] {
+input[type='button'],
+textarea {
   margin: 0;
   padding: 0;
   width: 100%;
@@ -78,10 +79,19 @@ input[type='button']:hover {
   background: rgba(0,0,0,0.05);
 }
 
-input[type='text'] {
+input[type='text'],
+textarea {
   cursor: text;
   line-height: 42px;
   text-indent: 10px;
+}
+
+textarea {
+  height: 96px;
+  resize: vertical;
+  line-height: 20px;
+  padding: 10px;
+  text-indent: 0;
 }
 
 .note p {
@@ -103,11 +113,34 @@ input[type='text'] {
 .blacklist-row {
   display: grid;
   gap: 8px;
+}
+
+.blacklist-form {
   grid-template-columns: 1fr 120px;
 }
 
 .blacklist-row {
   margin-top: 8px;
+  grid-template-columns: 1fr 120px;
+}
+
+.blacklist-actions {
+  display: grid;
+  gap: 8px;
+}
+
+#blacklist-file {
+  display: none;
+}
+
+#blacklist-status {
+  min-height: 20px;
+  color: #555;
+  text-indent: 5px;
+}
+
+#blacklist-status.error {
+  color: #b00020;
 }
 
 .logo {
@@ -116,6 +149,15 @@ input[type='text'] {
   border-bottom: solid 1px rgba(0,0,0,0.1);
   background: url('../icons/128.png') no-repeat center center;
   background-size: 64px;
+}
+
+@media (max-width: 640px) {
+  .blacklist-form {
+    grid-template-columns: 1fr;
+  }
+  .blacklist-actions {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -127,7 +169,8 @@ input[type='text'] {
   .container,
   .container select,
   .container input[type='text'],
-  .container input[type='button'] {
+  .container input[type='button'],
+  .container textarea {
     color: #ebebeb;
     background-color: #1e1e1e;
   }
@@ -138,12 +181,17 @@ input[type='text'] {
   .container label {
     color: #ebebeb;
   }
-  .container .note p {
+  .container .note p,
+  .container #blacklist-status {
     color: #b5b5b5;
+  }
+  .container #blacklist-status.error {
+    color: #ff8a80;
   }
   .container select,
   .container input[type='text'],
-  .container input[type='button'] {
+  .container input[type='button'],
+  .container textarea {
     border-color: rgb(255 255 255 / 10%);
   }
   .logo {

--- a/data/options/options.html
+++ b/data/options/options.html
@@ -70,35 +70,25 @@
           </td>
         </tr>
       </table>
-      <table class="blacklist">
-        <tr>
-          <td class="title">
-            <p><b>E</b>. Sites where WebRTC Control is disabled</p>
-          </td>
-        </tr>
-        <tr>
-          <td class="blacklist-form">
-            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
-            <div class="blacklist-actions">
-              <input type="button" id="blacklist-add" value="Add">
-              <input type="button" id="blacklist-import" value="Import">
-              <input type="button" id="blacklist-export" value="Export">
-              <input type="file" id="blacklist-file" accept=".json,.txt">
-            </div>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <p id="blacklist-status" aria-live="polite"></p>
-            <div id="blacklist-list"></div>
-          </td>
-        </tr>
-        <tr>
-          <td class="note">
-            <p>Note: matching sites do not receive page scripts, and the browser WebRTC policy is set to default while the matching tab is active.</p>
-          </td>
-        </tr>
-      </table>
+      <section class="blacklist">
+        <div class="title">
+          <p><b>E</b>. Sites where WebRTC Control is disabled</p>
+        </div>
+        <div class="blacklist-form">
+          <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
+          <div class="blacklist-actions">
+            <input type="button" id="blacklist-add" value="Add">
+            <input type="button" id="blacklist-import" value="Import">
+            <input type="button" id="blacklist-export" value="Export">
+            <input type="file" id="blacklist-file" accept=".json,.txt">
+          </div>
+        </div>
+        <p id="blacklist-status" aria-live="polite"></p>
+        <div id="blacklist-list"></div>
+        <div class="note">
+          <p>Note: matching sites do not receive page scripts, and the browser WebRTC policy is set to default while the matching tab is active.</p>
+        </div>
+      </section>
       <table class="buttons">
         <tr>
           <td><input type="button" id="test" value="Test WebRTC leak"></td>

--- a/data/options/options.html
+++ b/data/options/options.html
@@ -51,7 +51,7 @@
       <table class="select">
         <tr>
           <td class="title">
-            <p><b>C</b>. IP handling policy for WebRTC</p>
+            <p><b>D</b>. IP handling policy for WebRTC</p>
           </td>
         </tr>
         <tr>
@@ -67,6 +67,29 @@
         <tr>
           <td class="note">
             <p>Note: default option is - Disable non proxied udp</p>
+          </td>
+        </tr>
+      </table>
+      <table class="blacklist">
+        <tr>
+          <td class="title">
+            <p><b>E</b>. Sites where WebRTC Control is disabled</p>
+          </td>
+        </tr>
+        <tr>
+          <td class="blacklist-form">
+            <input type="text" id="blacklist-input" placeholder="example.com or *.example.com">
+            <input type="button" id="blacklist-add" value="Add">
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <div id="blacklist-list"></div>
+          </td>
+        </tr>
+        <tr>
+          <td class="note">
+            <p>Note: matching sites do not receive page scripts, and the browser WebRTC policy is set to default while the matching tab is active.</p>
           </td>
         </tr>
       </table>

--- a/data/options/options.html
+++ b/data/options/options.html
@@ -78,13 +78,13 @@
         </tr>
         <tr>
           <td class="blacklist-form">
+            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
             <div class="blacklist-actions">
               <input type="button" id="blacklist-add" value="Add">
               <input type="button" id="blacklist-import" value="Import">
               <input type="button" id="blacklist-export" value="Export">
               <input type="file" id="blacklist-file" accept=".json,.txt">
             </div>
-            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
           </td>
         </tr>
         <tr>

--- a/data/options/options.html
+++ b/data/options/options.html
@@ -78,12 +78,18 @@
         </tr>
         <tr>
           <td class="blacklist-form">
-            <input type="text" id="blacklist-input" placeholder="example.com or *.example.com">
-            <input type="button" id="blacklist-add" value="Add">
+            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
+            <div class="blacklist-actions">
+              <input type="button" id="blacklist-add" value="Add">
+              <input type="button" id="blacklist-import" value="Import">
+              <input type="button" id="blacklist-export" value="Export">
+              <input type="file" id="blacklist-file" accept=".json,.txt">
+            </div>
           </td>
         </tr>
         <tr>
           <td>
+            <p id="blacklist-status" aria-live="polite"></p>
             <div id="blacklist-list"></div>
           </td>
         </tr>

--- a/data/options/options.html
+++ b/data/options/options.html
@@ -78,13 +78,13 @@
         </tr>
         <tr>
           <td class="blacklist-form">
-            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
             <div class="blacklist-actions">
               <input type="button" id="blacklist-add" value="Add">
               <input type="button" id="blacklist-import" value="Import">
               <input type="button" id="blacklist-export" value="Export">
               <input type="file" id="blacklist-file" accept=".json,.txt">
             </div>
+            <textarea id="blacklist-input" placeholder="example.com, *.example.com, or one site per line"></textarea>
           </td>
         </tr>
         <tr>

--- a/data/options/options.js
+++ b/data/options/options.js
@@ -40,8 +40,11 @@ var config = {
     } catch (e) {}
     return entry.replace(/^www\./, "");
   },
-  "saveBlacklist": function () {
-    background.send("blacklist", {"blacklist": config.blacklist});
+  "saveBlacklist": function (list, callback) {
+    chrome.storage.local.set({"blacklist": list}, function () {
+      const error = chrome.runtime.lastError;
+      if (callback) callback(!error, error);
+    });
   },
   "renderBlacklist": function () {
     const list = document.querySelector("#blacklist-list");
@@ -60,18 +63,35 @@ var config = {
       /*  */
       input.addEventListener("change", function (e) {
         const value = config.normalize(e.target.value);
+        const next = config.blacklist.slice();
         if (value) {
-          config.blacklist[index] = value;
+          next[index] = value;
         } else {
-          config.blacklist.splice(index, 1);
+          next.splice(index, 1);
         }
-        config.saveBlacklist();
-        config.renderBlacklist();
+        config.saveBlacklist(next, function (ok, error) {
+          if (!ok) {
+            blacklistUI.status("Save failed. " + (error ? error.message : "Please try again."), true);
+            input.value = entry;
+            return;
+          }
+          config.blacklist = next;
+          config.renderBlacklist();
+          blacklistUI.status("Blacklist updated.");
+        });
       });
       remove.addEventListener("click", function () {
-        config.blacklist.splice(index, 1);
-        config.saveBlacklist();
-        config.renderBlacklist();
+        const next = config.blacklist.slice();
+        next.splice(index, 1);
+        config.saveBlacklist(next, function (ok, error) {
+          if (!ok) {
+            blacklistUI.status("Save failed. " + (error ? error.message : "Please try again."), true);
+            return;
+          }
+          config.blacklist = next;
+          config.renderBlacklist();
+          blacklistUI.status("Blacklist updated.");
+        });
       });
       /*  */
       row.appendChild(input);
@@ -102,6 +122,9 @@ var config = {
     const additional = document.querySelector("#additional");
     const blacklistAdd = document.querySelector("#blacklist-add");
     const blacklistInput = document.querySelector("#blacklist-input");
+    const blacklistImport = document.querySelector("#blacklist-import");
+    const blacklistExport = document.querySelector("#blacklist-export");
+    const blacklistFile = document.querySelector("#blacklist-file");
     /*  */
     test.addEventListener("click", function () {background.send("test")});
     support.addEventListener("click", function () {background.send("support")});
@@ -111,23 +134,158 @@ var config = {
     devices.addEventListener("change", function (e) {background.send("devices", {"devices": e.target.checked})});
     additional.addEventListener("change", function (e) {background.send("additional", {"additional": e.target.checked})});
     blacklistAdd.addEventListener("click", function () {
-      const value = config.normalize(blacklistInput.value);
-      if (value && config.blacklist.indexOf(value) === -1) {
-        config.blacklist.push(value);
-        config.saveBlacklist();
-        config.renderBlacklist();
-      }
-      blacklistInput.value = '';
+      blacklistUI.add(blacklistInput.value, "Added", function () {
+        blacklistInput.value = '';
+      });
       blacklistInput.focus();
     });
     blacklistInput.addEventListener("keydown", function (e) {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && e.ctrlKey) {
+        e.preventDefault();
         blacklistAdd.click();
       }
     });
+    blacklistImport.addEventListener("click", function () {
+      blacklistFile.value = '';
+      blacklistFile.click();
+    });
+    blacklistFile.addEventListener("change", function (e) {
+      blacklistUI.import(e.target.files && e.target.files.length ? e.target.files[0] : null);
+    });
+    blacklistExport.addEventListener("click", blacklistUI.export);
     /*  */
     background.send("load");
     window.removeEventListener("load", config.load, false);
+  }
+};
+
+var blacklistUI = {
+  "maxFileSize": 1024 * 1024,
+  "maxEntries": 5000,
+  "status": function (message, error) {
+    const status = document.querySelector("#blacklist-status");
+    if (!status) return;
+    status.textContent = message || '';
+    status.className = error ? "error" : '';
+  },
+  "splitLines": function (text) {
+    text = (text || '').replace(/^\uFEFF/, '');
+    return text.split(/\r?\n/).map(function (entry) {
+      return entry.trim();
+    }).filter(function (entry) {
+      return entry;
+    });
+  },
+  "merge": function (entries) {
+    const seen = {};
+    const next = [];
+    const stats = {"added": 0, "duplicates": 0, "invalid": 0};
+    /*  */
+    config.blacklist.forEach(function (entry) {
+      const value = config.normalize(entry);
+      if (value && !seen[value]) {
+        seen[value] = true;
+        next.push(value);
+      }
+    });
+    /*  */
+    entries.forEach(function (entry) {
+      if (typeof entry !== "string") {
+        stats.invalid += 1;
+        return;
+      }
+      const value = config.normalize(entry);
+      if (!value) {
+        stats.invalid += 1;
+        return;
+      }
+      if (seen[value]) {
+        stats.duplicates += 1;
+        return;
+      }
+      seen[value] = true;
+      next.push(value);
+      stats.added += 1;
+    });
+    /*  */
+    return {"list": next, "stats": stats};
+  },
+  "summary": function (verb, stats) {
+    return verb + " " + stats.added + " sites. Skipped " + stats.duplicates + " duplicates and " + stats.invalid + " invalid entries.";
+  },
+  "saveMerged": function (entries, verb, success) {
+    if (!entries.length) {
+      blacklistUI.status(blacklistUI.summary(verb, {"added": 0, "duplicates": 0, "invalid": 0}));
+      return;
+    }
+    if (entries.length > blacklistUI.maxEntries) {
+      blacklistUI.status("Import failed. Please use 5000 or fewer entries at a time.", true);
+      return;
+    }
+    const merged = blacklistUI.merge(entries);
+    config.saveBlacklist(merged.list, function (ok, error) {
+      if (!ok) {
+        blacklistUI.status("Save failed. " + (error ? error.message : "Please try again."), true);
+        return;
+      }
+      config.blacklist = merged.list;
+      config.renderBlacklist();
+      blacklistUI.status(blacklistUI.summary(verb, merged.stats));
+      if (success) success();
+    });
+  },
+  "add": function (text, verb, success) {
+    blacklistUI.saveMerged(blacklistUI.splitLines(text), verb, success);
+  },
+  "import": function (file) {
+    if (!file) return;
+    if (file.size > blacklistUI.maxFileSize) {
+      blacklistUI.status("Import failed. Please choose a file smaller than 1 MB.", true);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onerror = function () {
+      blacklistUI.status("Import failed. Please choose a valid JSON or TXT blacklist file.", true);
+    };
+    reader.onload = function () {
+      let entries = [];
+      const text = (reader.result || '').replace(/^\uFEFF/, '');
+      const name = (file.name || '').toLowerCase();
+      try {
+        if (name.endsWith(".json")) {
+          const data = JSON.parse(text);
+          if (!data || !Array.isArray(data.blacklist)) {
+            throw new Error("Missing blacklist array");
+          }
+          entries = data.blacklist;
+        } else {
+          entries = blacklistUI.splitLines(text);
+        }
+      } catch (e) {
+        blacklistUI.status("Import failed. Please choose a valid JSON or TXT blacklist file.", true);
+        return;
+      }
+      blacklistUI.saveMerged(entries, "Imported");
+    };
+    reader.readAsText(file);
+  },
+  "export": function () {
+    const now = new Date();
+    const date = now.getFullYear().toString() + String(now.getMonth() + 1).padStart(2, "0") + String(now.getDate()).padStart(2, "0");
+    const data = JSON.stringify({
+      "version": 1,
+      "blacklist": config.blacklist
+    }, null, 2);
+    const blob = new Blob([data], {"type": "application/json"});
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "webrtc-control-blacklist-" + date + ".json";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    blacklistUI.status("Exported " + config.blacklist.length + " sites.");
   }
 };
 

--- a/data/options/options.js
+++ b/data/options/options.js
@@ -219,7 +219,7 @@ var blacklistUI = {
       return;
     }
     if (entries.length > blacklistUI.maxEntries) {
-      blacklistUI.status("Import failed. Please use 5000 or fewer entries at a time.", true);
+      blacklistUI.status("Please use 5000 or fewer entries at a time.", true);
       return;
     }
     const merged = blacklistUI.merge(entries);

--- a/data/options/options.js
+++ b/data/options/options.js
@@ -29,6 +29,56 @@ var background = (function () {
 })();
 
 var config = {
+  "blacklist": [],
+  "normalize": function (entry) {
+    entry = (entry || '').trim().toLowerCase();
+    if (!entry) return '';
+    try {
+      if (/^https?:\/\//.test(entry)) {
+        entry = new URL(entry).hostname;
+      }
+    } catch (e) {}
+    return entry.replace(/^www\./, "");
+  },
+  "saveBlacklist": function () {
+    background.send("blacklist", {"blacklist": config.blacklist});
+  },
+  "renderBlacklist": function () {
+    const list = document.querySelector("#blacklist-list");
+    list.textContent = '';
+    /*  */
+    config.blacklist.forEach(function (entry, index) {
+      const row = document.createElement("div");
+      const input = document.createElement("input");
+      const remove = document.createElement("input");
+      /*  */
+      row.className = "blacklist-row";
+      input.type = "text";
+      input.value = entry;
+      remove.type = "button";
+      remove.value = "Remove";
+      /*  */
+      input.addEventListener("change", function (e) {
+        const value = config.normalize(e.target.value);
+        if (value) {
+          config.blacklist[index] = value;
+        } else {
+          config.blacklist.splice(index, 1);
+        }
+        config.saveBlacklist();
+        config.renderBlacklist();
+      });
+      remove.addEventListener("click", function () {
+        config.blacklist.splice(index, 1);
+        config.saveBlacklist();
+        config.renderBlacklist();
+      });
+      /*  */
+      row.appendChild(input);
+      row.appendChild(remove);
+      list.appendChild(row);
+    });
+  },
   "render": function (e) {
     const select = document.querySelector("#method");
     const inject = document.querySelector("#inject");
@@ -36,9 +86,11 @@ var config = {
     const additional = document.querySelector("#additional");
     /*  */
     if (e.webrtc) select.value = e.webrtc;
-    if (e.inject) inject.checked = e.inject;
-    if (e.devices) devices.checked = e.devices;
-    if (e.additional) additional.checked = e.additional;
+    if (e.inject !== undefined) inject.checked = e.inject;
+    if (e.devices !== undefined) devices.checked = e.devices;
+    if (e.additional !== undefined) additional.checked = e.additional;
+    config.blacklist = Array.isArray(e.blacklist) ? e.blacklist : [];
+    config.renderBlacklist();
   },
   "load": function () {
     const test = document.querySelector("#test");
@@ -48,6 +100,8 @@ var config = {
     const devices = document.querySelector("#devices");
     const donation = document.querySelector("#donation");
     const additional = document.querySelector("#additional");
+    const blacklistAdd = document.querySelector("#blacklist-add");
+    const blacklistInput = document.querySelector("#blacklist-input");
     /*  */
     test.addEventListener("click", function () {background.send("test")});
     support.addEventListener("click", function () {background.send("support")});
@@ -56,6 +110,21 @@ var config = {
     inject.addEventListener("change", function (e) {background.send("inject", {"inject": e.target.checked})});
     devices.addEventListener("change", function (e) {background.send("devices", {"devices": e.target.checked})});
     additional.addEventListener("change", function (e) {background.send("additional", {"additional": e.target.checked})});
+    blacklistAdd.addEventListener("click", function () {
+      const value = config.normalize(blacklistInput.value);
+      if (value && config.blacklist.indexOf(value) === -1) {
+        config.blacklist.push(value);
+        config.saveBlacklist();
+        config.renderBlacklist();
+      }
+      blacklistInput.value = '';
+      blacklistInput.focus();
+    });
+    blacklistInput.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") {
+        blacklistAdd.click();
+      }
+    });
     /*  */
     background.send("load");
     window.removeEventListener("load", config.load, false);

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -261,32 +261,37 @@ app.page = {
   },
   "send": function (id, data, tabId, frameId) {
     if (id) {
+      const message = {
+        "method": id, 
+        "data": data ? data : {}, 
+        "path": "background-to-page"
+      };
+      /*  */
+      if (tabId !== null && tabId !== undefined) {
+        if (frameId !== null && frameId !== undefined) {
+          chrome.tabs.sendMessage(tabId, message, {"frameId": frameId}, app.error);
+        } else {
+          chrome.tabs.sendMessage(tabId, message, app.error);
+        }
+        return;
+      }
+      /*  */
       chrome.tabs.query({}, function (tabs) {
         let tmp = chrome.runtime.lastError;
         if (tabs && tabs.length) {
-          const message = {
-            "method": id, 
-            "data": data ? data : {}, 
-            "path": "background-to-page"
-          };
-          /*  */
           tabs.forEach(function (tab) {
             if (tab) {
-              message.data.tabId = message.data.tabId ? message.data.tabId : tab.id;
-              message.data.top = message.data.top ? message.data.top : (tab.url ? tab.url : '');
-              message.data.title = message.data.title ? message.data.title : (tab.title ? tab.title : '');
+              const tabMessage = {
+                "method": message.method,
+                "path": message.path,
+                "data": Object.assign({}, message.data, {
+                  "tabId": tab.id,
+                  "top": tab.url ? tab.url : '',
+                  "title": tab.title ? tab.title : ''
+                })
+              };
               /*  */
-              if (tabId !== null && tabId !== undefined) {
-                if (tabId === tab.id) {
-                  if (frameId !== null && frameId !== undefined) {
-                    chrome.tabs.sendMessage(tab.id, message, {"frameId": frameId}, app.error);
-                  } else {
-                    chrome.tabs.sendMessage(tab.id, message, app.error);
-                  }
-                }
-              } else {
-                chrome.tabs.sendMessage(tab.id, message, app.error);
-              }
+              chrome.tabs.sendMessage(tab.id, tabMessage, app.error);
             }
           });
         }

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -180,6 +180,9 @@ app.on = {
     chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       app.storage.load(function () {
         callback(request, sender, sendResponse);
+        if (sendResponse) {
+          sendResponse({"ok": true});
+        }
       });
       /*  */
       return true;

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,7 @@
 var core = {
   "session": {
-    "allowlisted": false
+    "allowlisted": false,
+    "policy": ''
   },
   "blacklist": {
     "normalize": function (entry) {
@@ -86,6 +87,12 @@ var core = {
       const options = {};
       options.beta = {"scope": "regular", "value": state === "disabled"};
       options.alpha = state === "enabled" ? {"value": config.addon.webrtc} : {"value": "default"};
+      /*  */
+      if (core.session.policy === options.alpha.value + "::" + options.beta.value) {
+        return;
+      }
+      /*  */
+      core.session.policy = options.alpha.value + "::" + options.beta.value;
       /*  */
       app.privacy.network.webrtc.set(options, function (e) {
         if (config.log) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,4 +1,42 @@
 var core = {
+  "session": {
+    "allowlisted": false
+  },
+  "blacklist": {
+    "normalize": function (entry) {
+      entry = (entry || '').trim().toLowerCase();
+      if (!entry) return '';
+      try {
+        if (/^https?:\/\//.test(entry)) {
+          entry = new URL(entry).hostname;
+        }
+      } catch (e) {}
+      return entry.replace(/^\*\./, ".").replace(/^www\./, "");
+    },
+    "hostname": function (url) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          return parsed.hostname.toLowerCase().replace(/^www\./, "");
+        }
+      } catch (e) {}
+      return '';
+    },
+    "match": function (url) {
+      const hostname = core.blacklist.hostname(url);
+      const list = config.addon.blacklist;
+      if (!hostname || !Array.isArray(list)) return false;
+      /*  */
+      return list.some(function (entry) {
+        entry = core.blacklist.normalize(entry);
+        if (!entry) return false;
+        if (entry.charAt(0) === ".") {
+          entry = entry.slice(1);
+        }
+        return hostname === entry || hostname.endsWith("." + entry);
+      });
+    }
+  },
   "start": function () {
     core.load();
   },
@@ -6,7 +44,7 @@ var core = {
     core.load();
   },
   "load": function () {
-    core.action.update();
+    core.tab.active();
     /*  */
     app.contextmenu.create({
       "contexts": ["action"],
@@ -16,7 +54,7 @@ var core = {
   },
   "action": {
     "storage": function (changes, namespace) {
-      /*  */
+      core.tab.active();
     },
     "contextmenu": function () {
       app.tab.open(config.webrtc.test.page);
@@ -30,21 +68,24 @@ var core = {
     },
     "page": {
       "load": function (e) {
+        const blocked = core.blacklist.match(e ? (e.top || '') : '');
         app.page.send("storage", {
-          "state": config.addon.state,
-          "inject": config.addon.inject,
-          "devices": config.addon.devices,
-          "additional": config.addon.additional
+          "state": blocked ? "disabled" : config.addon.state,
+          "blocked": blocked,
+          "inject": blocked ? false : config.addon.inject,
+          "devices": blocked ? false : config.addon.devices,
+          "additional": blocked ? false : config.addon.additional
         }, e ? e.tabId : '', e ? e.frameId : '');
       }
     },
     "update": function () {
-      app.button.icon(null, config.addon.state);
-      app.button.title(null, "WebRTC leak protection is " + (config.addon.state === "enabled" ? "ON" : "OFF"));
+      const state = core.session.allowlisted ? "disabled" : config.addon.state;
+      app.button.icon(null, state);
+      app.button.title(null, core.session.allowlisted ? "WebRTC leak protection is OFF on this site" : "WebRTC leak protection is " + (state === "enabled" ? "ON" : "OFF"));
       /*  */
       const options = {};
-      options.beta = {"scope": "regular", "value": config.addon.state === "disabled"};
-      options.alpha = config.addon.state === "enabled" ? {"value": config.addon.webrtc} : {"value": "default"};
+      options.beta = {"scope": "regular", "value": state === "disabled"};
+      options.alpha = state === "enabled" ? {"value": config.addon.webrtc} : {"value": "default"};
       /*  */
       app.privacy.network.webrtc.set(options, function (e) {
         if (config.log) {
@@ -68,6 +109,11 @@ var core = {
         /*  */
         core.action.update();
       },
+      "blacklist": function (e) {
+        config.addon.blacklist = Array.isArray(e.blacklist) ? e.blacklist : [];
+        /*  */
+        core.tab.active();
+      },
       "webrtc": function (e) {
         config.addon.webrtc = e.webrtc;
         config.addon.state = config.addon.webrtc === "default" ? "disabled" : "enabled";
@@ -79,9 +125,27 @@ var core = {
           "webrtc": config.addon.webrtc,
           "inject": config.addon.inject,
           "devices": config.addon.devices,
-          "additional": config.addon.additional
+          "additional": config.addon.additional,
+          "blacklist": config.addon.blacklist
         });
       }
+    }
+  },
+  "tab": {
+    "update": function (tab) {
+      core.session.allowlisted = tab && tab.url ? core.blacklist.match(tab.url) : false;
+      core.action.update();
+    },
+    "active": function () {
+      if (!chrome.tabs) {
+        core.session.allowlisted = false;
+        core.action.update();
+        return;
+      }
+      chrome.tabs.query({"active": true, "currentWindow": true}, function (tabs) {
+        const tmp = chrome.runtime.lastError;
+        core.tab.update(tabs && tabs.length ? tabs[0] : null);
+      });
     }
   }
 };
@@ -95,6 +159,7 @@ app.options.receive("load", core.action.options.load);
 app.options.receive("inject", core.action.options.inject);
 app.options.receive("webrtc", core.action.options.webrtc);
 app.options.receive("devices", core.action.options.devices);
+app.options.receive("blacklist", core.action.options.blacklist);
 app.options.receive("additional", core.action.options.additional);
 app.options.receive("support", function () {app.tab.open(app.homepage())});
 app.options.receive("test", function () {app.tab.open(config.webrtc.test.page)});
@@ -103,3 +168,19 @@ app.options.receive("donation", function () {app.tab.open(app.homepage() + "?rea
 app.on.startup(core.start);
 app.on.installed(core.install);
 app.on.storage(core.action.storage);
+
+if (chrome.tabs) {
+  chrome.tabs.onActivated.addListener(function () {
+    app.storage.load(core.tab.active);
+  });
+  chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+    if (changeInfo.url || changeInfo.status === "loading") {
+      chrome.tabs.query({"active": true, "currentWindow": true}, function (tabs) {
+        const tmp = chrome.runtime.lastError;
+        if (tabs && tabs.length && tabs[0].id === tabId) {
+          app.storage.load(function () {core.tab.update(tab)});
+        }
+      });
+    }
+  });
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,10 +14,12 @@ config.addon = {
   set inject (val) {app.storage.write("inject", val)},
   set webrtc (val) {app.storage.write("webrtc", val)},
   set devices (val) {app.storage.write("devices", val)},
+  set blacklist (val) {app.storage.write("blacklist", val)},
   set additional (val) {app.storage.write("additional", val)},
   get inject () {return app.storage.read("inject") !== undefined ? app.storage.read("inject") : true},
   get state () {return app.storage.read("state") !== undefined ? app.storage.read("state") : "enabled"},
   get devices () {return app.storage.read("devices") !== undefined ? app.storage.read("devices") : false},
+  get blacklist () {return app.storage.read("blacklist") !== undefined ? app.storage.read("blacklist") : []},
   get additional () {return app.storage.read("additional") !== undefined ? app.storage.read("additional") : false},
   get webrtc () {return app.storage.read("webrtc") !== undefined ? app.storage.read("webrtc") : "disable_non_proxied_udp"}
 };

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
-  "version": "0.3.5",
+  "version": "3.4.0",
+  "version_name": "3.4.0-dev-1.2",
   "manifest_version": 3,
   "name": "WebRTC Control",
   "homepage_url": "https://mybrowseraddon.com/webrtc-control.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.4.0.12",
-  "version_name": "3.4.0.1.2",
+  "version": "0.3.3.12",
+  "version_name": "0.3.3.12",
   "manifest_version": 3,
   "name": "WebRTC Control",
   "homepage_url": "https://mybrowseraddon.com/webrtc-control.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.3.3.12",
-  "version_name": "0.3.3.12",
+  "version": "0.3.4.3",
+  "version_name": "0.3.4.3",
   "manifest_version": 3,
   "name": "WebRTC Control",
   "homepage_url": "https://mybrowseraddon.com/webrtc-control.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.4.0",
-  "version_name": "3.4.0-dev-1.2",
+  "version": "3.4.0.12",
+  "version_name": "3.4.0.1.2",
   "manifest_version": 3,
   "name": "WebRTC Control",
   "homepage_url": "https://mybrowseraddon.com/webrtc-control.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.4",
+  "version": "0.3.5",
   "manifest_version": 3,
   "name": "WebRTC Control",
   "homepage_url": "https://mybrowseraddon.com/webrtc-control.html",
@@ -17,6 +17,7 @@
   "permissions": [
     "privacy", 
     "storage", 
+    "tabs",
     "contextMenus"
   ],
   "web_accessible_resources": [{


### PR DESCRIPTION
## Summary

This pull request adds a disabled-sites list to WebRTC Control.

The extension currently works globally, but some users need WebRTC Control to stay enabled by default while being disabled on specific sites. This change adds an options-page section where users can manage those sites without changing browser-level extension permissions.

## Changes

- Adds a new options-page section: **Sites where WebRTC Control is disabled**
- Allows users to add, edit, and remove disabled site entries
- Stores the disabled-sites list in `chrome.storage.local`
- Skips page-context WebRTC blocking scripts on matching sites
- Temporarily restores the browser WebRTC policy to `default` when the active tab matches a disabled site
- Adds the `tabs` permission so the extension can detect the active tab URL
- Bumps the extension version to `0.3.5`

## Matching behavior

Entries are matched by hostname. Supported examples:

```text
example.com
www.example.com
*.example.com
https://example.com/path
URL entries are normalized to their hostname.

Note
Chrome's webRTCIPHandlingPolicy setting is global rather than per-site. Because of that, this implementation restores the WebRTC policy based on the active tab. When the user switches away from a disabled site, the configured protection policy is applied again.

Testing
Checked JavaScript syntax with node --check
Parsed manifest.json successfully
